### PR TITLE
chore: replace ico favicon with svg

### DIFF
--- a/web/app/favicon.svg
+++ b/web/app/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" rx="3" fill="#4A90E2"/>
+  <path d="M4 4h8v2H6v2h4v2H6v2H4V4z" fill="#fff"/>
+</svg>

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,0 +1,14 @@
+export const metadata = {
+  title: 'Fundo',
+  icons: {
+    icon: '/favicon.svg',
+  },
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary
- add vector favicon
- reference favicon.svg in app layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2aec39df0832c83aeb3e84c9b0da7