### PR TITLE
feat: use svg icon component

### DIFF
--- a/web/app/favicon.svg
+++ b/web/app/favicon.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
-  <rect width="16" height="16" rx="3" fill="#4A90E2"/>
-  <path d="M4 4h8v2H6v2h4v2H6v2H4V4z" fill="#fff"/>
-</svg>

--- a/web/app/icon.tsx
+++ b/web/app/icon.tsx
@@ -1,0 +1,22 @@
+import { ImageResponse } from 'next/server';
+
+export const size = {
+  width: 16,
+  height: 16,
+};
+
+export const contentType = 'image/svg+xml';
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+        <rect width="16" height="16" rx="3" fill="#4A90E2" />
+        <path d="M4 4h8v2H6v2h4v2H6v2H4V4z" fill="#fff" />
+      </svg>
+    ),
+    {
+      ...size,
+    }
+  );
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,8 +1,5 @@
 export const metadata = {
   title: 'Fundo',
-  icons: {
-    icon: '/favicon.svg',
-  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## Summary
- replace static favicon with dynamic `icon.tsx`
- remove favicon metadata to rely on Next.js defaults

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b7439680832cad078801520a4cb9