### PR TITLE
Add Dockerfiles and refine compose for dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,21 +2,21 @@ version: '3.9'
 
 services:
   server:
-    image: python:3.11-slim
+    build: ./server
     working_dir: /app
     volumes:
       - ./server:/app
-    command: sh -c "pip install -r requirements.txt && python manage.py runserver 0.0.0.0:8000"
     env_file:
       - server/.env
     ports:
       - "8000:8000"
 
   web:
-    image: node:20
+    build: ./web
     working_dir: /app
     volumes:
       - ./web:/app
+      - /app/node_modules
     command: npm run dev
     env_file:
       - web/.env

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+
+# Builder stage: install dependencies
+FROM python:3.11-slim AS builder
+WORKDIR /app
+
+# Install build dependencies and Python packages
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+COPY requirements.txt .
+RUN pip install --prefix=/install --no-cache-dir -r requirements.txt
+
+# Final stage: runtime image
+FROM python:3.11-slim AS runtime
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+
+COPY --from=builder /install /usr/local
+COPY . .
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+
+# Install dependencies (cached)
+FROM node:20 AS deps
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+
+# Build application
+FROM node:20 AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+# Production dependencies only
+FROM node:20-alpine AS prod-deps
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# Final runtime image
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=prod-deps /app/node_modules ./node_modules
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/next.config.ts ./next.config.ts
+COPY package*.json ./
+EXPOSE 3000
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile for Python server
- add multi-stage Dockerfile for Next.js web app with cached node_modules
- update docker-compose to build images and mount only source code

## Testing
- `python -m py_compile $(git ls-files 'server/**/*.py' 'server/*.py')`
- `npm ci`
- `npm run lint`
- `docker compose build server web` *(fails: command not found: docker)*


------
https://chatgpt.com/codex/tasks/task_e_68b345762ed0832ca18e66fc4d183ebe