### PR TITLE
Load environment variables from .env files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - ./server:/app
     env_file:
       - server/.env
+    environment:
+      DJANGO_SETTINGS_MODULE: server.settings.dev
     ports:
       - "8000:8000"
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,8 +1,8 @@
-SECRET_KEY=your-secret-key
+SECRET_KEY=changeme
+DEBUG=True
 DB_ENGINE=django.db.backends.sqlite3
 DB_NAME=db.sqlite3
 DB_USER=
 DB_PASSWORD=
-DB_HOST=localhost
-DB_PORT=5432
-DJANGO_SETTINGS_MODULE=server.settings.dev
+DB_HOST=
+DB_PORT=

--- a/server/server/settings/base.py
+++ b/server/server/settings/base.py
@@ -13,15 +13,20 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 import os
 from pathlib import Path
 
+from dotenv import load_dotenv
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
+
+# Load environment variables from the project .env file.
+load_dotenv(BASE_DIR / ".env")
 
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv("SECRET_KEY", "unsafe-secret-key")
+SECRET_KEY = os.environ["SECRET_KEY"]
 
 ALLOWED_HOSTS = (
     os.getenv("ALLOWED_HOSTS", "").split(",") if os.getenv("ALLOWED_HOSTS") else []

--- a/server/server/settings/dev.py
+++ b/server/server/settings/dev.py
@@ -1,3 +1,5 @@
+import os
+
 from .base import *  # noqa: F403
 
-DEBUG = True
+DEBUG = os.getenv("DEBUG", "True").lower() == "true"

--- a/server/server/settings/prod.py
+++ b/server/server/settings/prod.py
@@ -1,3 +1,5 @@
+import os
+
 from .base import *  # noqa: F403
 
-DEBUG = False
+DEBUG = os.getenv("DEBUG", "False").lower() == "true"


### PR DESCRIPTION
## Summary
- load `.env` via python-dotenv in Django settings
- read DEBUG from the environment in dev/prod modules
- supply DJANGO_SETTINGS_MODULE via docker-compose

## Testing
- `python server/manage.py test`
- `npm --prefix web run lint`
- `pre-commit run --files server/server/settings/base.py server/server/settings/dev.py server/server/settings/prod.py docker-compose.yml server/.env.example`


------
https://chatgpt.com/codex/tasks/task_e_68b9bd4d1f90832ca4581fa32c2c0601